### PR TITLE
Add festival to exec_depend for rosdep

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -9,6 +9,7 @@
 
   <exec_depend>rclpy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
+  <exec_depend>festival</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>


### PR DESCRIPTION
This will automatically install festival-tts library using rosdep